### PR TITLE
Use struct for checkTypes rather than a plain map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # Konstant
 
 Konstant is a tool to help on security scanning and benchmarking.
+
+## Add new check types
+1. Under core, add file for new check type ([sample check type](core/mount.go))
+    1. Define type that describe new check type and implement core.Runner and
+    core.checker interfaces
+2. Under checks, add new checktype file with ([sample check type](checks/mount.go)):
+    1. Define types to define check specific parameters
+    2. add an unmarshal function to unmarshal the yaml input for that specific check type
+    3. Add it to checkTypes using checkTypes.add() from within init() function.
+
+## Add new checks
+1. Create or update yaml files in your config directory ([sample cfg](cfg/))
+    defining check type and parameters.

--- a/checks/checks.go
+++ b/checks/checks.go
@@ -26,7 +26,18 @@ type check struct {
 	Params interface{}
 }
 
-var checkTypes = make(map[string]func(func(interface{}) error) (interface{}, core.Runner, error))
+type checkType struct {
+	types map[string]func(func(interface{}) error) (interface{}, core.Runner, error)
+}
+
+func (ct *checkType) add(name string, f func(func(interface{}) error) (interface{}, core.Runner, error)) {
+	ct.types[name] = f
+}
+
+// This one will be used to add new check types
+var checkTypes = checkType{
+	types: make(map[string]func(func(interface{}) error) (interface{}, core.Runner, error)),
+}
 
 func (c *check) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
@@ -45,7 +56,7 @@ func (c *check) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	c.Desc = d.Desc
 	c.Scored = d.Scored
 	var err error
-	if ct := checkTypes[t.Type]; ct != nil {
+	if ct := checkTypes.types[t.Type]; ct != nil {
 		c.Params, c.checkType, err = ct(unmarshal)
 		if err != nil {
 			return err

--- a/checks/module.go
+++ b/checks/module.go
@@ -13,8 +13,8 @@ type kernelModuleCheck struct {
 }
 
 func init() {
-	//Add unmarshal function to checkTypes map, so Unmarshal can call it
-	checkTypes["kernelModule"] = unmarshalKernelModuleCheck
+	//Add unmarshal function to checkTypes, so Unmarshal can call it
+	checkTypes.add("kernelModule", unmarshalKernelModuleCheck)
 }
 
 //Unmarshal params
@@ -23,5 +23,5 @@ func unmarshalKernelModuleCheck(unmarshal func(interface{}) error) (param interf
 	if err := unmarshal(&km); err != nil {
 		return param, chk, err
 	}
-	return km.Params, core.KernelModule{Name: km.Params.Name},  nil
+	return km.Params, core.KernelModule{Name: km.Params.Name}, nil
 }

--- a/checks/mount.go
+++ b/checks/mount.go
@@ -13,9 +13,9 @@ type mountPointCheck struct {
 }
 
 func init() {
-	//Add unmarshal functions to checkTypes map, so Unmarshal can call it
-	checkTypes["mountPoint"] = unmarshalMountPointCheck
-	checkTypes["mountOption"] = unmarshalMountOptionCheck
+	//Add unmarshal functions to checkTypes, so Unmarshal can call it
+	checkTypes.add("mountPoint", unmarshalMountPointCheck)
+	checkTypes.add("mountOption", unmarshalMountOptionCheck)
 }
 
 //Handle unmarshalling inputs configuration


### PR DESCRIPTION
using struct will enable abstracting process of adding new check type by
implementing an "add" method.